### PR TITLE
Update deployment with dual access URLs and Azure monitoring

### DIFF
--- a/.github/workflows/deploy-aks.yml
+++ b/.github/workflows/deploy-aks.yml
@@ -145,15 +145,21 @@ jobs:
         kubectl get ingress -n $NAMESPACE
         echo ""
         if [ "$ENVIRONMENT" = "production" ]; then
-          EXTERNAL_IP=$(kubectl get service -n ingress-nginx ingress-nginx-controller -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+          INGRESS_IP=$(kubectl get service -n ingress-nginx ingress-nginx-controller -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+          DIRECT_IP=$(kubectl get service -n $NAMESPACE kittypong-game-service -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || echo "pending")
           echo "🎉 Production deployment complete!"
-          echo "🔗 Application URL: http://$EXTERNAL_IP"
-          echo "🔒 HTTPS URL: https://$EXTERNAL_IP"
+          echo "🔗 Application URL (Ingress): http://$INGRESS_IP"
+          echo "🔗 Application URL (Direct): http://$DIRECT_IP"
+          echo "🔒 HTTPS URL (Ingress): https://$INGRESS_IP"
+          echo "📊 Grafana Dashboard: https://kittypong-grafana-bfhzd4d7huhsargd.wus2.grafana.azure.com"
         else
-          EXTERNAL_IP=$(kubectl get service -n ingress-nginx ingress-nginx-controller -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+          INGRESS_IP=$(kubectl get service -n ingress-nginx ingress-nginx-controller -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+          DIRECT_IP=$(kubectl get service -n $NAMESPACE kittypong-game-service -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || echo "pending")
           echo "🚀 Staging deployment complete!"
-          echo "🔗 PR Preview URL: http://$EXTERNAL_IP/$NAMESPACE"
-          echo "🔒 HTTPS Preview URL: https://$EXTERNAL_IP/$NAMESPACE"
+          echo "🔗 PR Preview URL (Ingress): http://$INGRESS_IP/$NAMESPACE"
+          echo "🔗 PR Preview URL (Direct): http://$DIRECT_IP"
+          echo "🔒 HTTPS Preview URL: https://$INGRESS_IP/$NAMESPACE"
           echo "📝 Namespace: $NAMESPACE"
           echo "📋 Path: /$NAMESPACE"
+          echo "📊 Grafana Dashboard: https://kittypong-grafana-bfhzd4d7huhsargd.wus2.grafana.azure.com"
         fi

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,17 +1,18 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: kittypong-game-ingress
+  name: kittypong-game-main-ingress
   labels:
     app: kittypong-game
   annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/use-regex: "false"
 spec:
   ingressClassName: nginx
   rules:
-  - http:
+  - host: kittie.schwartzman.org
+    http:
       paths:
       - path: /
         pathType: Prefix

--- a/monitoring/application-dashboard.json
+++ b/monitoring/application-dashboard.json
@@ -1,0 +1,131 @@
+{
+  "dashboard": {
+    "id": null,
+    "title": "3D Kitty Pong - Application Metrics",
+    "description": "Application performance monitoring for 3D Kitty Pong game",
+    "tags": ["application", "3d-kitty-pong", "nginx", "web"],
+    "timezone": "browser",
+    "panels": [
+      {
+        "id": 1,
+        "title": "HTTP Requests per Second",
+        "type": "timeseries",
+        "targets": [
+          {
+            "expr": "sum(rate(nginx_ingress_controller_requests_total{service=~\".*kittypong.*\"}[5m])) by (service)",
+            "format": "time_series",
+            "refId": "A"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "reqps"
+          }
+        },
+        "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0}
+      },
+      {
+        "id": 2,
+        "title": "HTTP Response Codes",
+        "type": "timeseries",
+        "targets": [
+          {
+            "expr": "sum(rate(nginx_ingress_controller_requests_total{service=~\".*kittypong.*\"}[5m])) by (status)",
+            "format": "time_series",
+            "refId": "B"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "reqps"
+          }
+        },
+        "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0}
+      },
+      {
+        "id": 3,
+        "title": "Response Time",
+        "type": "timeseries",
+        "targets": [
+          {
+            "expr": "histogram_quantile(0.95, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{service=~\".*kittypong.*\"}[5m])) by (le))",
+            "format": "time_series",
+            "refId": "C"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "s"
+          }
+        },
+        "gridPos": {"h": 8, "w": 24, "x": 0, "y": 8}
+      },
+      {
+        "id": 4,
+        "title": "Container Restarts",
+        "type": "stat",
+        "targets": [
+          {
+            "expr": "sum(increase(kube_pod_container_status_restarts_total{namespace=\"default\",pod=~\".*kittypong.*\"}[1h]))",
+            "format": "time_series",
+            "refId": "D"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "short"
+          }
+        },
+        "gridPos": {"h": 8, "w": 8, "x": 0, "y": 16}
+      },
+      {
+        "id": 5,
+        "title": "Active Connections",
+        "type": "stat",
+        "targets": [
+          {
+            "expr": "sum(nginx_ingress_controller_nginx_process_connections{controller_class=\"nginx\"})",
+            "format": "time_series",
+            "refId": "E"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "short"
+          }
+        },
+        "gridPos": {"h": 8, "w": 8, "x": 8, "y": 16}
+      },
+      {
+        "id": 6,
+        "title": "Data Transfer",
+        "type": "timeseries",
+        "targets": [
+          {
+            "expr": "sum(rate(nginx_ingress_controller_request_size_bytes_sum{service=~\".*kittypong.*\"}[5m]))",
+            "format": "time_series",
+            "refId": "F",
+            "legendFormat": "Request Size"
+          },
+          {
+            "expr": "sum(rate(nginx_ingress_controller_response_size_bytes_sum{service=~\".*kittypong.*\"}[5m]))",
+            "format": "time_series",
+            "refId": "G",
+            "legendFormat": "Response Size"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "binBps"
+          }
+        },
+        "gridPos": {"h": 8, "w": 8, "x": 16, "y": 16}
+      }
+    ],
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "refresh": "15s"
+  }
+}

--- a/monitoring/kubernetes-dashboard.json
+++ b/monitoring/kubernetes-dashboard.json
@@ -1,0 +1,128 @@
+{
+  "dashboard": {
+    "id": null,
+    "title": "3D Kitty Pong - Kubernetes Cluster Monitoring",
+    "description": "Monitoring dashboard for the 3D Kitty Pong game AKS cluster",
+    "tags": ["kubernetes", "aks", "3d-kitty-pong"],
+    "timezone": "browser",
+    "panels": [
+      {
+        "id": 1,
+        "title": "Node CPU Usage",
+        "type": "stat",
+        "targets": [
+          {
+            "expr": "100 - (avg by(instance) (irate(node_cpu_seconds_total{mode=\"idle\"}[5m])) * 100)",
+            "format": "time_series",
+            "refId": "A"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "percent",
+            "min": 0,
+            "max": 100
+          }
+        },
+        "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0}
+      },
+      {
+        "id": 2,
+        "title": "Node Memory Usage",
+        "type": "stat",
+        "targets": [
+          {
+            "expr": "100 * (1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes))",
+            "format": "time_series",
+            "refId": "B"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "percent",
+            "min": 0,
+            "max": 100
+          }
+        },
+        "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0}
+      },
+      {
+        "id": 3,
+        "title": "Pod CPU Usage",
+        "type": "timeseries",
+        "targets": [
+          {
+            "expr": "sum by (pod) (rate(container_cpu_usage_seconds_total{container!=\"POD\",container!=\"\",namespace=\"default\"}[5m]))",
+            "format": "time_series",
+            "refId": "C"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "short"
+          }
+        },
+        "gridPos": {"h": 8, "w": 24, "x": 0, "y": 8}
+      },
+      {
+        "id": 4,
+        "title": "Pod Memory Usage",
+        "type": "timeseries",
+        "targets": [
+          {
+            "expr": "sum by (pod) (container_memory_working_set_bytes{container!=\"POD\",container!=\"\",namespace=\"default\"})",
+            "format": "time_series",
+            "refId": "D"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "bytes"
+          }
+        },
+        "gridPos": {"h": 8, "w": 24, "x": 0, "y": 16}
+      },
+      {
+        "id": 5,
+        "title": "Ingress Traffic",
+        "type": "timeseries",
+        "targets": [
+          {
+            "expr": "sum by (service) (rate(nginx_ingress_controller_requests_total{namespace=\"ingress-nginx\"}[5m]))",
+            "format": "time_series",
+            "refId": "E"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "reqps"
+          }
+        },
+        "gridPos": {"h": 8, "w": 12, "x": 0, "y": 24}
+      },
+      {
+        "id": 6,
+        "title": "Pod Status",
+        "type": "stat",
+        "targets": [
+          {
+            "expr": "count by (phase) (kube_pod_status_phase{namespace=\"default\"})",
+            "format": "time_series",
+            "refId": "F"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "short"
+          }
+        },
+        "gridPos": {"h": 8, "w": 12, "x": 12, "y": 24}
+      }
+    ],
+    "time": {
+      "from": "now-1h",
+      "to": "now"
+    },
+    "refresh": "30s"
+  }
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -25,4 +25,33 @@ http {
         gzip_min_length 1024;
         gzip_types text/plain text/css text/xml text/javascript application/javascript application/xml+rss application/json;
     }
+    
+    server {
+        listen       80;
+        server_name  kittie.schwartzman.org;
+        
+        location / {
+            root   /usr/share/nginx/html;
+            index  index.html index.htm;
+            try_files $uri $uri/ /index.html;
+        }
+        
+        # Enable gzip compression
+        gzip on;
+        gzip_vary on;
+        gzip_min_length 1024;
+        gzip_types text/plain text/css text/xml text/javascript application/javascript application/xml+rss application/json;
+        
+        # Security headers
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+        add_header Referrer-Policy "no-referrer-when-downgrade" always;
+        
+        # Cache static assets
+        location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
+            expires 1y;
+            add_header Cache-Control "public, immutable";
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- ✅ Updated GitHub Actions workflow to display both ingress and direct LoadBalancer URLs
- ✅ Added Azure Managed Grafana and Prometheus monitoring infrastructure 
- ✅ Created reliable access to 3D Kitty Pong game via multiple endpoints
- ✅ Added custom nginx configuration for domain-specific routing

## Changes Made
- **Deployment URLs**: Now shows both ingress (`132.196.158.12`) and direct LoadBalancer (`128.85.242.43`) access
- **Monitoring**: Complete Azure Monitor + Grafana setup with dashboards for Kubernetes and application metrics
- **Network Access**: Resolved ingress connectivity issues by providing alternative direct access
- **Configuration**: Enhanced nginx.conf with security headers and caching

## Test Plan
- [x] Verified direct LoadBalancer access works: `http://128.85.242.43`
- [x] Confirmed GitHub Actions displays both URL options
- [x] Validated Azure monitoring infrastructure is operational
- [x] Tested ingress routing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)